### PR TITLE
🔥  Remove Docs from Header

### DIFF
--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -68,26 +68,15 @@ const NavItems = () => {
           </NavItem>
         ))}
       {!LIVE && (
-        <>
-          <NavItem>
-            <Link
-              onClick={() => {
-                (window as any).open("https://backdfund.medium.com/", "_blank").focus();
-              }}
-            >
-              blog
-            </Link>
-          </NavItem>
-          <NavItem>
-            <Link
-              onClick={() => {
-                (window as any).open("https://backd-1.gitbook.io/backd/", "_blank").focus();
-              }}
-            >
-              docs
-            </Link>
-          </NavItem>
-        </>
+        <NavItem>
+          <Link
+            onClick={() => {
+              (window as any).open("https://backdfund.medium.com/", "_blank").focus();
+            }}
+          >
+            blog
+          </Link>
+        </NavItem>
       )}
     </StyledNavItems>
   );


### PR DESCRIPTION
The Docs will not be ready until closer to mainnet launch.  
And so they should be removed from the header for now until they can be released.