### PR TITLE
🐛  Fix Discord Link Expiry

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,7 +18,7 @@ const linkLists: LinkListType[] = [
     links: [
       {
         label: "Discord",
-        link: "https://discord.gg/gtwzyjGa",
+        link: "https://discord.gg/jpGvaFV3Rv",
       },
       {
         label: "Twitter",


### PR DESCRIPTION
The current Discord link expires after 7 days.  
This PR updates it to a version that never expires.