### PR TITLE
⚡  Change Header Logo to use React Router

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
+
 import logo from "../assets/logo/logo.svg";
 import { LIVE } from "../lib/constants";
 import Connector from "./Connector";
@@ -63,9 +65,9 @@ const Header = (): JSX.Element => {
 
   return (
     <StyledHeader isSticky={scrollPosition > 40}>
-      <a href="/">
+      <Link to="/">
         <Logo src={logo} alt="Backd logo" />
-      </a>
+      </Link>
       <NavItems />
       {LIVE && <Connector />}
     </StyledHeader>


### PR DESCRIPTION
It was using `<a>` tag before, which rerendered the whole page whenever it was used.  
Now it just switches to that page so is more performant.