### PR TITLE
🚀  Add Token Symbol to Position Header

### DIFF
--- a/src/pages/pool/PoolPositions.tsx
+++ b/src/pages/pool/PoolPositions.tsx
@@ -137,7 +137,7 @@ const PoolPositions = ({ pool }: Props): JSX.Element => {
 
   return (
     <ContentSection
-      header="Top-up positions"
+      header={`Top-up ${pool.underlying.symbol} positions`}
       statistics={<PoolStatistics pool={pool} />}
       content={
         <>


### PR DESCRIPTION
When testing the app I was regularly forgetting which token I was on the position page for.  
To solve this, the Token Symbol has been added to the Top-up position page, similar to how we have for the Deposit and Withdraw page.  
![image](https://user-images.githubusercontent.com/53957795/128954812-584433da-e570-436f-b113-b0141c22c4df.png)