### PR TITLE
🚀  Add Support for ENS Wallet Display

### DIFF
--- a/src/components/Connector.tsx
+++ b/src/components/Connector.tsx
@@ -1,9 +1,11 @@
 import { useWeb3React } from "@web3-react/core";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+
 import { GradientText } from "../styles/GradientText";
 import WalletSelectPopup from "./WalletSelectPopup";
 import { shortenAddress } from "../lib/text";
+import { useBackd } from "../app/hooks/use-backd";
 
 type ConnectedType = {
   connected: boolean;
@@ -40,7 +42,8 @@ const ConnectorButton = styled.button`
   position: relative;
   cursor: pointer;
   height: 4.2rem;
-  width: ${(props: ConnectedType) => (props.connected ? "13.3rem" : "15.8rem")};
+  width: ${(props: ConnectedType) => (props.connected ? "auto" : "15.8rem")};
+  padding: ${(props: ConnectedType) => (props.connected ? "0 2rem" : "0")};
   border-radius: ${(props: ConnectedType) => (props.connected ? "1.4rem" : "2.1rem")};
   background-color: ${(props: ConnectedType) => (props.connected ? "none" : "var(--main)")};
   border: ${(props: ConnectedType) =>
@@ -116,13 +119,35 @@ const DotCenter = styled.div`
 const Connector = (): JSX.Element => {
   const { account, active } = useWeb3React();
   const [connecting, setConnecting] = useState(false);
+  const [ens, setEns] = useState("");
+  const backd = useBackd();
+
+  const updateEns = async () => {
+    if (!account || !backd) return;
+    try {
+      const ens = await backd.provider.lookupAddress(account);
+      if (ens) {
+        setEns(ens);
+        return;
+      }
+    } catch {
+      console.log("ENS Not Supported");
+    }
+    setEns("");
+  };
+
+  useEffect(() => {
+    updateEns();
+  }, [account, updateEns, backd]);
 
   return (
     <>
       <DesktopConnector>
         <Aura connected={active} />
         <ConnectorButton onClick={() => setConnecting(true)} connected={active}>
-          <ConnectorText>{account ? shortenAddress(account, 8) : "Connnect wallet"}</ConnectorText>
+          <ConnectorText>
+            {account ? ens || shortenAddress(account, 8) : "Connnect wallet"}
+          </ConnectorText>
         </ConnectorButton>
       </DesktopConnector>
       <MobileConnector onClick={() => setConnecting(true)}>


### PR DESCRIPTION
Defaults to normal address if there is no ENS for the address.  
Only works on supported networks.

Before:
![image](https://user-images.githubusercontent.com/53957795/129001665-b7681b91-dced-49b5-9f7b-403e12bbc9af.png)

After:
![image](https://user-images.githubusercontent.com/53957795/129001698-eef253a9-c84a-4a81-9464-ecdf4f92f105.png)
