### PR TITLE
🐛  Fix Issue with Mobile Footer Element Ordering

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -81,10 +81,6 @@ const StyledFooter = styled.div`
 
   @media (max-width: 600px) {
     flex-direction: column;
-
-    div:nth-child(5) {
-      order: -1;
-    }
   }
 `;
 


### PR DESCRIPTION
A bug was introduced when we removed the email signup section.  
The footer was showing elements in the wrong order:
![image](https://user-images.githubusercontent.com/53957795/129159995-ce42ee8d-636a-4eb7-a39e-af1124967e7f.png)
This PR fixes the issue so they display as expected:
![image](https://user-images.githubusercontent.com/53957795/129160045-74a1a495-2a57-4698-a8d0-ce73b6391161.png)
