### PR TITLE
✅  Fix Issue With Flakey Percy Tests

### DIFF
--- a/cypress/integration/landing-page_spec.js
+++ b/cypress/integration/landing-page_spec.js
@@ -1,3 +1,5 @@
+import { percySnapshot } from "../support";
+
 describe("Innitial Load", () => {
   it("Should Load Home Page", () => {
     cy.visit("/");
@@ -185,6 +187,6 @@ describe("Footer", () => {
 
 describe("Percy", () => {
   it("Should Screenshot Landing Page", () => {
-    cy.percySnapshot();
+    percySnapshot();
   });
 });

--- a/cypress/integration/language-spec.js
+++ b/cypress/integration/language-spec.js
@@ -1,3 +1,5 @@
+import { percySnapshot } from "../support";
+
 const isEnglish = () => {
   cy.get("h1").contains("Reactive Liquidity");
   cy.get("h3").contains(
@@ -48,7 +50,7 @@ describe("Language Switching", () => {
   });
 
   it("Percy Should Screenshot Chinese Landing Page", () => {
-    cy.percySnapshot();
+    percySnapshot();
   });
 
   it("Should Change Language back to English", () => {

--- a/cypress/integration/litepaper_spec.js
+++ b/cypress/integration/litepaper_spec.js
@@ -1,3 +1,5 @@
+import { percySnapshot } from "../support";
+
 describe("Innitial Load", () => {
   it("Should Load Litepaper Page", () => {
     cy.visit("/litepaper");
@@ -12,6 +14,6 @@ describe("Page Content", () => {
 
 describe("Percy", () => {
   it("Should Screenshot Litepaper Page", () => {
-    cy.percySnapshot();
+    percySnapshot();
   });
 });

--- a/cypress/integration/not-found-page_spec.js
+++ b/cypress/integration/not-found-page_spec.js
@@ -1,3 +1,5 @@
+import { percySnapshot } from "../support";
+
 describe("Innitial Load", () => {
   it("Should Load Not Found Page", () => {
     cy.visit("/askkasklaslkaskjl");
@@ -58,6 +60,6 @@ describe("External Links", () => {
 
 describe("Percy", () => {
   it("Should Screenshot Not Found Page", () => {
-    cy.percySnapshot();
+    percySnapshot();
   });
 });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,6 @@
 import "@percy/cypress";
+
+export const percySnapshot = () => {
+  cy.wait(200);
+  cy.percySnapshot();
+};


### PR DESCRIPTION
Some elements that animate were being screenshotted in different positions which was triggering false positives for Percy tests.  
This PR adds a short delay before screenshotting which should allow all elements enough time to complete their animations before the screenshot is taken.