### PR TITLE
Add logic to fallback to Binance when coingecko is not accessible

### DIFF
--- a/src/lib/backd.ts
+++ b/src/lib/backd.ts
@@ -8,7 +8,8 @@ import { TopUpAction } from "@backdfund/protocol/typechain/TopUpAction";
 import { TopUpActionFactory } from "@backdfund/protocol/typechain/TopUpActionFactory";
 import { BigNumber, ContractTransaction, ethers, providers, Signer, utils } from "ethers";
 import { UnsupportedNetwork } from "../app/errors";
-import { getPrices } from "./coingecko";
+import { getPrices as getPricesFromCoingecko } from "./coingecko";
+import { getPrices as getPricesFromBinance } from "./binance";
 import { ETH_DECIMALS, ETH_DUMMY_ADDRESS, INFINITE_APPROVE_AMMOUNT } from "./constants";
 import { bigNumberToFloat, scale } from "./numeric";
 import { ScaledNumber } from "./scaled-number";
@@ -276,9 +277,13 @@ export class Web3Backd implements Backd {
   }
 
   async getPrices(symbols: string[]): Promise<Prices> {
-    return getPrices(symbols).catch((e) => {
-      throw new Error(`failed to fetch prices: ${e.message}`);
-    });
+    return getPricesFromCoingecko(symbols)
+      .catch((e) => {
+        return getPricesFromBinance(symbols);
+      })
+      .catch((e) => {
+        throw new Error(`failed to fetch prices: ${e.message}`);
+      });
   }
 
   async listSupportedProtocols(): Promise<string[]> {

--- a/src/lib/binance.test.ts
+++ b/src/lib/binance.test.ts
@@ -1,0 +1,8 @@
+import { getPrices } from "./binance";
+
+test("fetches prices from Binance", async () => {
+  const prices = await getPrices(["DAI", "USDC", "ETH"]);
+  expect(prices.DAI).toBeCloseTo(1, 0.01);
+  expect(prices.USDC).toBeCloseTo(1, 0.01);
+  expect(prices.ETH).toBeGreaterThan(0);
+});

--- a/src/lib/binance.ts
+++ b/src/lib/binance.ts
@@ -1,0 +1,16 @@
+import { Prices } from "./types";
+
+const apiBaseURL = "https://api.binance.com/api/v3";
+
+type PriceResponse = { symbol: string; price: string };
+
+async function fetchPrice(symbol: string, quote: string): Promise<PriceResponse> {
+  const url = `${apiBaseURL}/ticker/price?symbol=${symbol}${quote}`;
+  return (await fetch(url)).json();
+}
+
+export async function getPrices(symbols: string[], quote = "USDT"): Promise<Prices> {
+  const requests = symbols.map((s) => fetchPrice(s, quote));
+  const responses = await Promise.all(requests);
+  return Object.fromEntries(responses.map((res, i) => [symbols[i], Number(res.price)]));
+}


### PR DESCRIPTION
I added a fallback to Binance when we were unable to fetch the prices from Coingecko. The quote is in USDT instead of USD so there might be some slight variations in the price but hopefully it should be within the realm of acceptable.