### PR TITLE
🐛  Fixed Issue with Percent Slider Not Working for Some Locales

### DIFF
--- a/src/lib/numeric.ts
+++ b/src/lib/numeric.ts
@@ -90,7 +90,7 @@ export const formatPercent = (number: number): string => {
 export const formatCrypto = (number: number, parameters: Intl.NumberFormatOptions = {}): string => {
   let decimals = Math.max(5 - Math.floor(number ** (1 / 10)), 0);
   if (number < 0.0001) decimals = 18;
-  return number.toLocaleString(undefined, {
+  return number.toLocaleString("un-US", {
     maximumFractionDigits: decimals,
     ...parameters,
   });


### PR DESCRIPTION
We had an issue where the percent slider wasn't working for some locales.  
This is because the output string was formatted differently which broke the number conversion.  
This is fixed here by setting it to always output in the `en-US` locale.