### PR TITLE
📈  Add Fathom Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,9 @@
       gtag("config", "G-S4PJ5XNE70");
     </script>
 
+    <!-- Fathom -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="GCODIILI" defer></script>
+
     <!-- Twitter universal website tag code -->
     <script>
       !(function (e, t, n, s, u, a) {


### PR DESCRIPTION
We are considering Fathom as an alternative to Google Analytics.  
To try this out we are looking to run it in parallel with GA to learn more about the differences in how they track data.