### PR TITLE
🔧  Increase Delay Before Taking Screenshot

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -3,6 +3,6 @@ import "@percy/cypress";
 export const percySnapshot = () => {
   // This delay is to give time for animations to finish before taking screenshots
   // We had some flakiness before from animations still being in progress
-  cy.wait(1000);
+  cy.wait(2000);
   cy.percySnapshot();
 };


### PR DESCRIPTION
We are still having issues with flakey snapshot tests from animation delays.  
Increasing the delay further in hopes it will resolve the issue.