### PR TITLE
🔧  Remove State Persist for User Data

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -34,7 +34,7 @@ const rootReducer = combineReducers({
 const persistConfig = {
   key: "root",
   version: 1,
-  blacklist: ["error"],
+  blacklist: ["error", "user", "positions", "transactions"],
   storage,
 };
 

--- a/src/lib/scaled-number.ts
+++ b/src/lib/scaled-number.ts
@@ -21,6 +21,7 @@ export class ScaledNumber {
   }
 
   static fromPlain(value: PlainScaledNumber): ScaledNumber {
+    if (!value) return new ScaledNumber();
     return new ScaledNumber(BigNumber.from(value.value), value.decimals);
   }
 


### PR DESCRIPTION
Currently we persist all of the state in local storage.  
This is good for making the site load faster on subsequent visits.  
However it is prone to causing bugs when the state of the user becomes corrupted.  
And also can cause issues when changes are made to the structure of the state.

This PR changes what we persist to only the Pool data.  
That way the page loads are still snappy for `pools` and `pool`, with only the user balances not showing immediately.