### PR TITLE
🐛  Fixed Issue With Total Pool Deposits Not Including Positions

### DIFF
--- a/src/pages/pool/PoolPositions.tsx
+++ b/src/pages/pool/PoolPositions.tsx
@@ -1,19 +1,16 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import styled from "styled-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import ContentSection from "../../components/ContentSection";
 import NewPosition from "./NewPosition";
 import Tooltip from "../../components/Tooltip";
 import { Pool } from "../../lib";
-import { fetchPositions, selectPoolPositions } from "../../state/positionsSlice";
-import { AppDispatch } from "../../app/store";
-import { useBackd } from "../../app/hooks/use-backd";
+import { selectPoolPositions } from "../../state/positionsSlice";
 import { Position } from "../../lib/types";
 import PositionRow from "./PositionRow";
 import PoolStatistics from "./PoolStatistics";
-import { useWeb3Updated } from "../../app/hooks/use-web3-updated";
 
 type HeaderType = {
   label: string;
@@ -129,22 +126,14 @@ type Props = {
 const PoolPositions = ({ pool }: Props): JSX.Element => {
   const { t } = useTranslation();
   const positions = useSelector(selectPoolPositions(pool));
-  const dispatch = useDispatch<AppDispatch>();
-  const backd = useBackd();
   const [showShadow, setShowShadow] = useState(true);
   const positionContentRef = useRef<HTMLDivElement>(null);
-  const updated = useWeb3Updated();
 
   const handleScroll = () => {
     setShowShadow(
       (positionContentRef.current?.getBoundingClientRect().right || 1000) > window.innerWidth
     );
   };
-
-  useEffect(() => {
-    if (!backd) return;
-    dispatch(fetchPositions({ backd }));
-  }, [updated]);
 
   return (
     <ContentSection

--- a/src/state/poolsListSlice.ts
+++ b/src/state/poolsListSlice.ts
@@ -3,6 +3,7 @@ import { AppThunk, RootState } from "../app/store";
 import { Pool } from "../lib";
 import { Backd } from "../lib/backd";
 import { Prices } from "../lib/types";
+import { fetchPositions } from "./positionsSlice";
 import { fetchAllowances, fetchBalances } from "./userSlice";
 
 interface PoolsState {
@@ -67,6 +68,7 @@ export const fetchState =
       dispatch(fetchPrices({ backd, pools }));
       dispatch(fetchAllowances({ backd, pools }));
     });
+    dispatch(fetchPositions({ backd }));
   };
 
 export const selectPools = (state: RootState): Pool[] => state.pools.pools;


### PR DESCRIPTION
We were previously only fetching the position data when we went to the top-up tab.  
The issue with this is that this data is included in the `Your Deposits` statistic.  
And so this value was wrong until the user visited the top-up tab.  
Now we fetch this data on the load of the Pool and Pools page so it is up to date.