### PR TITLE
💄  Standardise Currency Displays

### DIFF
--- a/src/lib/numeric.ts
+++ b/src/lib/numeric.ts
@@ -75,12 +75,10 @@ export const numberToCompactCurrency = (value: number): string => {
 };
 
 export const formatCurrency = (number: number): string => {
-  return number.toLocaleString(undefined, {
+  return `$${number.toLocaleString(undefined, {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
-    style: "currency",
-    currency: "USD",
-  });
+  })}`;
 };
 
 export const formatPercent = (number: number): string => {

--- a/src/lib/scaled-number.ts
+++ b/src/lib/scaled-number.ts
@@ -1,5 +1,11 @@
 import { BigNumber } from "ethers";
-import { bigNumberToString, formatCrypto, formatCurrency, stringToBigNumber } from "./numeric";
+import {
+  bigNumberToString,
+  formatCrypto,
+  formatCurrency,
+  numberToCompactCurrency,
+  stringToBigNumber,
+} from "./numeric";
 
 export interface PlainScaledNumber {
   value: string;
@@ -103,4 +109,7 @@ export class ScaledNumber {
     formatCrypto(Number(this.toString()), parameters);
 
   toUsdValue = (price: number): string => formatCurrency(Number(this.toString()) * price);
+
+  toCompactUsdValue = (price: number): string =>
+    numberToCompactCurrency(Number(this.toString()) * price);
 }

--- a/src/pages/pools/PoolsRow.tsx
+++ b/src/pages/pools/PoolsRow.tsx
@@ -148,9 +148,7 @@ const PoolsRow = ({ pool, preview }: Props): JSX.Element => {
           <Apy>{formatPercent(pool.apy)}</Apy>
         </Data>
         <Data>{numberToCompactCurrency(pool.totalAssets * price)}</Data>
-        <DepositedData preview={preview}>
-          {formatCurrency(Number(locked.toString()) * price)}
-        </DepositedData>
+        <DepositedData preview={preview}>{locked.toCompactUsdValue(price)}</DepositedData>
         <ChevronData preview={preview}>
           <Chevron src={chevron} alt="right arrow" />
         </ChevronData>


### PR DESCRIPTION
Previously we had some inconsistent formatting for currencies:
![image](https://user-images.githubusercontent.com/53957795/134828519-d070866c-3f93-4760-98aa-06f5cc6fdf45.png)
Some values displayed with a `US` prefix, and some were compact and some in full.  
This has now been changed to the below:
![image](https://user-images.githubusercontent.com/53957795/134828532-9a78fdd0-b5be-4e72-a4e6-51eb00259e38.png)
`US` prefixes have been removed.  
And now any overview value displays as shortened, while any detail value displays in full.  
So the pool row shows the overview values, then once you click into the pool you can see the detailed values at the top:
![image](https://user-images.githubusercontent.com/53957795/134828567-48161f66-ad67-42cc-aa45-74594d8b46fd.png)
This is in line with how other protocols handle this such as:
- Compound
- Aave
- Convex
- Curve

An exception to this is Yearn which always shows the full values and not the shortened version.