### PR TITLE
🦔  Remove Language Percy Snapshots

### DIFF
--- a/cypress/integration/language-spec.js
+++ b/cypress/integration/language-spec.js
@@ -88,10 +88,6 @@ describe("Language Switching", () => {
     isChinese();
   });
 
-  it("Percy Should Screenshot Chinese Landing Page", () => {
-    percySnapshot();
-  });
-
   it("Should Change Language to Japanese", () => {
     cy.get('[id="language-selector"]').click();
     cy.get('[id="ja"]').click();
@@ -99,10 +95,6 @@ describe("Language Switching", () => {
 
   it("Should Show Japanese", () => {
     isJapanese();
-  });
-
-  it("Percy Should Screenshot Japanese Landing Page", () => {
-    percySnapshot();
   });
 
   it("Should Change Language to Spanish", () => {
@@ -114,10 +106,6 @@ describe("Language Switching", () => {
     isSpanish();
   });
 
-  it("Percy Should Screenshot Spanish Landing Page", () => {
-    percySnapshot();
-  });
-
   it("Should Change Language to French", () => {
     cy.get('[id="language-selector"]').click();
     cy.get('[id="fr"]').click();
@@ -125,10 +113,6 @@ describe("Language Switching", () => {
 
   it("Should Show French", () => {
     isFrench();
-  });
-
-  it("Percy Should Screenshot French Landing Page", () => {
-    percySnapshot();
   });
 
   it("Should Change Language back to English", () => {


### PR DESCRIPTION
We're running a bit tight on available Percy snapshots, this is going to be made worse soon with the introduction of the protocol pages snapshots.  
After a quick review, the snapshots we were taking of the landing page in each language was making up the majority of our snapshots.  
They are unlikely to deliver much value, as all the code is the same other than the language text, so if something is broken in English, then it most likely will be for the other languages also and visa-versa.  
This is also a bit unscalable, as if we had 50 languages in future, it wouldn't be practical to take 50 snapshots for each language.  
These have been removed in this PR.