### PR TITLE
🎨  Add FromEntries Polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "classnames": "^2.2.6",
     "ethers": "^5.4.0",
     "formik": "^2.2.6",
+    "fromentries": "^1.3.2",
     "i18next": "^20.3.5",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "^1.3.0",

--- a/src/lib/backd.ts
+++ b/src/lib/backd.ts
@@ -7,6 +7,8 @@ import { StakerVaultFactory } from "@backdfund/protocol/typechain/StakerVaultFac
 import { TopUpAction } from "@backdfund/protocol/typechain/TopUpAction";
 import { TopUpActionFactory } from "@backdfund/protocol/typechain/TopUpActionFactory";
 import { BigNumber, ContractTransaction, ethers, providers, Signer, utils } from "ethers";
+import fromEntries from "fromentries";
+
 import { UnsupportedNetwork } from "../app/errors";
 import { getPrices as getPricesFromCoingecko } from "./coingecko";
 import { getPrices as getPricesFromBinance } from "./binance";
@@ -285,7 +287,7 @@ export class Web3Backd implements Backd {
   async getBalances(addresses: string[], account?: string): Promise<Balances> {
     const promises = addresses.map((a) => this.getBalance(a, account));
     const balances = await Promise.all(promises);
-    return Object.fromEntries(addresses.map((a, i) => [a, balances[i]]));
+    return fromEntries(addresses.map((a, i) => [a, balances[i]]));
   }
 
   async getPrices(symbols: string[]): Promise<Prices> {

--- a/src/lib/binance.ts
+++ b/src/lib/binance.ts
@@ -1,3 +1,4 @@
+import fromEntries from "fromentries";
 import { Prices } from "./types";
 
 const apiBaseURL = "https://api.binance.com/api/v3";
@@ -12,5 +13,5 @@ async function fetchPrice(symbol: string, quote: string): Promise<PriceResponse>
 export async function getPrices(symbols: string[], quote = "USDT"): Promise<Prices> {
   const requests = symbols.map((s) => fetchPrice(s, quote));
   const responses = await Promise.all(requests);
-  return Object.fromEntries(responses.map((res, i) => [symbols[i], Number(res.price)]));
+  return fromEntries(responses.map((res, i) => [symbols[i], Number(res.price)]));
 }

--- a/src/lib/mock/backd.ts
+++ b/src/lib/mock/backd.ts
@@ -1,4 +1,6 @@
 import { BigNumber, ContractTransaction, providers } from "ethers";
+import fromEntries from "fromentries";
+
 import { Pool } from "..";
 import { Backd } from "../backd";
 import { bigNumberToFloat } from "../numeric";
@@ -79,12 +81,12 @@ export default class MockBackd implements Backd {
 
   async getBalances(pools: Address[], account?: Address): Promise<Balances> {
     const balances = await Promise.all(pools.map((p) => this.getBalance(p, account)));
-    return Object.fromEntries(pools.map((p, i) => [p, balances[i]]));
+    return fromEntries(pools.map((p, i) => [p, balances[i]]));
   }
 
   getPrices(symbols: string[]): Promise<Prices> {
     return Promise.resolve(
-      Object.fromEntries(
+      fromEntries(
         symbols.map((symbol) => [symbol, bigNumberToFloat(prices[symbol] || BigNumber.from(0))])
       )
     );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,6 @@
 import { TransactionReceipt } from "@ethersproject/providers";
+import fromEntries from "fromentries";
+
 import { PlainScaledNumber, ScaledNumber } from "./scaled-number";
 
 export type Optional<T> = T | null;
@@ -94,11 +96,11 @@ export type Balances = Record<string, ScaledNumber>;
 export type PlainBalances = Record<string, PlainScaledNumber>;
 
 export const toPlainBalances = (balances: Balances): PlainBalances => {
-  return Object.fromEntries(Object.entries(balances).map(([key, value]) => [key, value.toPlain()]));
+  return fromEntries(Object.entries(balances).map(([key, value]) => [key, value.toPlain()]));
 };
 
 export const fromPlainBalances = (balances: PlainBalances): Balances => {
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(balances).map(([key, value]) => [key, ScaledNumber.fromPlain(value)])
   );
 };
@@ -107,13 +109,13 @@ export type Allowances = Record<string, Balances>;
 export type PlainAllowances = Record<string, PlainBalances>;
 
 export const toPlainAllowances = (allowances: Allowances): PlainAllowances => {
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(allowances).map(([key, value]) => [key, toPlainBalances(value)])
   );
 };
 
 export const fromPlainAllowances = (allowances: PlainAllowances): Allowances => {
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(allowances).map(([key, value]) => [key, fromPlainBalances(value)])
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7175,6 +7175,11 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fromentries@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
+
 fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"


### PR DESCRIPTION
We were regularly receiving issue reports from users on browsers that do not support the `Object.fromEntries` function.  
This PR replaces calls to this function to use the polyfill instead.