### PR TITLE
👷  Fix Deployment Pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn run percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          CYPRESS_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
   deploy:
     needs: [unit_test, build, cypress_test]
     runs-on: ubuntu-latest
@@ -70,3 +71,5 @@ jobs:
         run: yarn
       - name: run cypress
         run: CYPRESS_baseUrl=https://backd.fund/ npx cypress run
+        env:
+          CYPRESS_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
The Cypress Private Key Environment Variable was missing in the deployment pipeline so it couldn't initialise Web3