### PR TITLE
🦔  Hide Variable Values on Percy Snapshot

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -20,6 +20,10 @@ const Available = styled.div`
   letter-spacing: 0.15px;
   margin-bottom: 1rem;
   padding-right: 0.5rem;
+
+  @media only percy {
+    opacity: 0;
+  }
 `;
 
 interface Props {

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -68,6 +68,10 @@ const Value = styled.div`
     font-size: 1.4rem;
     line-height: 1.8rem;
   }
+
+  @media only percy {
+    opacity: 0;
+  }
 `;
 
 const Usd = styled.div`
@@ -81,6 +85,10 @@ const Usd = styled.div`
   @media (max-width: 600px) {
     font-size: 1.2rem;
     line-height: 1.6rem;
+  }
+
+  @media only percy {
+    opacity: 0;
   }
 `;
 

--- a/src/pages/pools/PoolsRow.tsx
+++ b/src/pages/pools/PoolsRow.tsx
@@ -55,6 +55,7 @@ const Row = styled.tr`
 type DataProps = {
   right?: boolean;
   preview?: boolean;
+  hideOnSnapshot?: boolean;
 };
 
 const Data = styled.td`
@@ -74,6 +75,10 @@ const Data = styled.td`
     line-height: 2.1rem;
     display: ${(props: DataProps) => (props.right ? "none" : "flex")};
   }
+
+  @media only percy {
+    opacity: ${(props: DataProps) => (props.hideOnSnapshot ? "0" : "1")};
+  }
 `;
 
 const DepositedData = styled(Data)`
@@ -81,6 +86,10 @@ const DepositedData = styled(Data)`
 
   @media (max-width: 600px) {
     display: none;
+  }
+
+  @media only percy {
+    opacity: 0;
   }
 `;
 
@@ -149,10 +158,10 @@ const PoolsRow = ({ pool, preview }: Props): JSX.Element => {
         <Data>
           <Asset token={pool.underlying} />
         </Data>
-        <Data>
+        <Data hideOnSnapshot>
           <Apy>{formatPercent(pool.apy)}</Apy>
         </Data>
-        <Data>{numberToCompactCurrency(pool.totalAssets * price)}</Data>
+        <Data hideOnSnapshot>{numberToCompactCurrency(pool.totalAssets * price)}</Data>
         <DepositedData preview={preview}>{locked.toCompactUsdValue(price)}</DepositedData>
         <ChevronData preview={preview}>
           <Chevron src={chevron} alt="right arrow" />


### PR DESCRIPTION
Percy is currently throwing false negatives for snapshots because of differences found in variable values, for example a pool TVL.  
This PR introduces some conditional css that hides them when taking the snapshots.