### PR TITLE
🚀  Reduce Limit For Proceeding From Top-up Deposit Flow

### DIFF
--- a/cypress/integration/action-page_spec.js
+++ b/cypress/integration/action-page_spec.js
@@ -493,9 +493,12 @@ describe("Top-up Position Confirmation", () => {
   });
   it("Should redirect to actions on completion", () => {
     cy.get("#register-action-button", { timeout: WEB3_TIMEOUT }).should("exist");
-    cy.location().should((loc) => {
-      expect(loc.pathname).to.eq("/actions");
-    });
+    cy.location().should(
+      (loc) => {
+        expect(loc.pathname).to.eq("/actions");
+      },
+      { timeout: WEB3_TIMEOUT }
+    );
   });
 });
 

--- a/src/pages/actions/lending/RegisterTopupPoolDeposit.tsx
+++ b/src/pages/actions/lending/RegisterTopupPoolDeposit.tsx
@@ -7,17 +7,11 @@ import { useSelector } from "react-redux";
 import ContentSection from "../../../components/ContentSection";
 import Button from "../../../components/Button";
 import { selectPool } from "../../../state/selectors";
-import {
-  GWEI_DECIMALS,
-  GWEI_SCALE,
-  TOPUP_ACTION_ROUTE,
-  TOPUP_GAS_COST,
-} from "../../../lib/constants";
+import { TOPUP_ACTION_ROUTE } from "../../../lib/constants";
 import PoolDeposit from "../../pool/PoolDeposit";
 import { useDevice } from "../../../app/hooks/use-device";
 import { selectBalances } from "../../../state/userSlice";
 import { ScaledNumber } from "../../../lib/scaled-number";
-import { selectEthPrice, selectPrices } from "../../../state/poolsListSlice";
 
 interface TopupParams {
   address: string;
@@ -63,8 +57,6 @@ const RegisterTopupPoolDeposit = () => {
   const { isMobile } = useDevice();
   const pool = useSelector(selectPool(poolName));
   const balances = useSelector(selectBalances);
-  const prices = useSelector(selectPrices);
-  const ethPrice = useSelector(selectEthPrice);
 
   if (!pool) {
     history.push("/");
@@ -74,11 +66,7 @@ const RegisterTopupPoolDeposit = () => {
   const hasSufficientBalance = () => {
     const lpBalance = balances[pool.lpToken.address];
     if (!lpBalance) return false;
-    const usdBalance = lpBalance.mul(prices[pool.underlying.symbol]);
-    const gasCostUsd = new ScaledNumber(
-      ScaledNumber.fromUnscaled(50, GWEI_DECIMALS).value.mul(TOPUP_GAS_COST).div(GWEI_SCALE)
-    ).mul(ethPrice);
-    return usdBalance.gte(gasCostUsd);
+    return lpBalance.gt(new ScaledNumber());
   };
 
   return (


### PR DESCRIPTION
Previously the user had to deposit a specific amount before proceeding. But this should not really be a hard restriction as it's up to the user how much they want to deposit. And is confusing when the don't deposit enough and can't proceed. This PR changes it so they just have to deposit at least some amount.