### PR TITLE
🐛  Fix Out of Gas Error and Update Browser List

### DIFF
--- a/cypress/integration/action-page_spec.js
+++ b/cypress/integration/action-page_spec.js
@@ -490,6 +490,7 @@ describe("Top-up Position Confirmation", () => {
   });
   it("Should Confirm", () => {
     cy.get("#register-topup-confirmation-popup-button").should("be.enabled");
+    cy.wait(10_000);
     cy.get("#register-topup-confirmation-popup-button").click();
   });
   it("Should disable button", () => {

--- a/src/lib/backd.ts
+++ b/src/lib/backd.ts
@@ -229,7 +229,7 @@ export class Web3Backd implements Backd {
     const protocol = utils.formatBytes32String(position.protocol);
     const depositAmount = position.maxTopUp.value.mul(rawExchangeRate).div(scale);
 
-    return this.topupAction.register(
+    const gasEstimate = await this.topupAction.estimateGas.register(
       position.account,
       protocol,
       position.threshold.value,
@@ -239,6 +239,21 @@ export class Web3Backd implements Backd {
       position.singleTopUp.value,
       position.maxTopUp.value,
       position.maxGasPrice.value
+    );
+    const gasLimit = gasEstimate.mul(12).div(10);
+    return this.topupAction.register(
+      position.account,
+      protocol,
+      position.threshold.value,
+      pool.lpToken.address,
+      depositAmount,
+      pool.underlying.address,
+      position.singleTopUp.value,
+      position.maxTopUp.value,
+      position.maxGasPrice.value,
+      {
+        gasLimit,
+      }
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,9 +4767,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001280:
-  version "1.0.30001283"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz#8573685bdae4d733ef18f78d44ba0ca5fe9e896b"
-  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
+  version "1.0.30001284"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz"
+  integrity sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We were having an issue with running out of gas for some transactions when registering top-ups. This PR ads a gas buffer to try and minimise the chance of this happening.

Also in this PR is an update to browser lists.