### PR TITLE
📝  Update Aave References to Aave v2

### DIFF
--- a/cypress/integration/action-page_spec.js
+++ b/cypress/integration/action-page_spec.js
@@ -81,7 +81,7 @@ describe("Register Page", () => {
   });
   it("Should have Top-up Note", () => {
     cy.get("#top-up-note").contains(
-      "Use your Backd deposits as back-up collateral to protect your overcollateralised loans on Aave or Compound from getting liquidated."
+      "Use your Backd deposits as back-up collateral to protect your overcollateralised loans on Aave v2 or Compound from getting liquidated."
     );
   });
   it("Should take snapshot", () => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -28,7 +28,7 @@ const sendCrypto = (privateKey) => {
   contract.methods
     .transfer(address, web3.utils.toWei("500", "ether"))
     .send({ from: ADDRESS })
-    .on("receipt", () => {
+    .on("transactionHash", () => {
       web3.eth.sendTransaction({
         from: ADDRESS,
         to: address,

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -105,7 +105,7 @@
           "register": {
             "number": "02",
             "header": "Register Loan on-Chain",
-            "description": "Register Compound or Aave loans on-chain to receive collateral top-ups, and stake your pool LP tokens to earn Backd rewards."
+            "description": "Register Compound or Aave v2 loans on-chain to receive collateral top-ups, and stake your pool LP tokens to earn Backd rewards."
           },
           "protect": {
             "number": "03",
@@ -237,7 +237,7 @@
       "what": {
         "header": "What is a Top-up Position?",
         "paragraph1": "A top-up is the act of depositing additional collateral in order to increase the health factor of your loan or mitigate liquidation risk. Backd liquidity providers can use their Backd LP tokens to register Top-up Positions. This creates back up collateral or what you could call interest earning liquidation protection. When a user registers a Top-up Position they must specify how much of their Backd liquidity should be shifted and at what health factor a top-up should occur. After registering a Top-up Position the Backd user’s liquidity will continue to be allocated to yield-farming strategies until it is needed.",
-        "paragraph2": "Backd’s Top-up Positions increase collateral efficiency by enabling any borrower on supported protocols (Backd will support Aave & Compound loans at launch) to earn yield with their collateral. Furthermore this also enables borrowers to increase leverage by depositing less collateral and hedge liquidation risk by automatically posting extra collateral when needed.",
+        "paragraph2": "Backd’s Top-up Positions increase collateral efficiency by enabling any borrower on supported protocols (Backd will support Aave v2 & Compound loans at launch) to earn yield with their collateral. Furthermore this also enables borrowers to increase leverage by depositing less collateral and hedge liquidation risk by automatically posting extra collateral when needed.",
         "paragraph3": "Backd creates an infrastructure that enables the combination of on-chain actions, off-chain keepers that react to market events, and yield-farming. This unique combination lends itself to a multitude of actions and integration with many protocols. Backd not only makes liquidity more efficient, but also makes other protocols safer and smarter."
       }
     },
@@ -441,7 +441,7 @@
     },
     "topup": {
       "label": "Top-up Position",
-      "description": "Use your Backd deposits as back-up collateral to protect your overcollateralised loans on Aave or Compound from getting liquidated.",
+      "description": "Use your Backd deposits as back-up collateral to protect your overcollateralised loans on Aave v2 or Compound from getting liquidated.",
       "stages": {
         "loan": {
           "header": "Select a loan to protect",
@@ -480,12 +480,12 @@
       "fields": {
         "protocol": {
           "label": "Protocol",
-          "tooltip": "The lending protocol on which the user is borrowing funds (currently compatible with Aave and Compound)",
+          "tooltip": "The lending protocol on which the user is borrowing funds (currently compatible with Aave v2 and Compound)",
           "hover": "Select protocol"
         },
         "address": {
           "label": "Address",
-          "tooltip": "The address of the owner of the position to top-up (e.g. if Alice is the borrower on Aave that should be topped up then this would be Alice’s address)",
+          "tooltip": "The address of the owner of the position to top-up (e.g. if Alice is the borrower on Aave v2 that should be topped up then this would be Alice’s address)",
           "hover": "Enter address",
           "required": "Address is required",
           "invalid": "Invalid address",
@@ -633,15 +633,15 @@
     },
     "litepaper": {
       "title": "Backd Litepaper",
-      "description": "How Backd combines actions (e.g. Aave & Compound liquidation protection) with yield-farming (Curve & Convex)"
+      "description": "How Backd combines actions (e.g. Aave v2 & Compound liquidation protection) with yield-farming (Curve & Convex)"
     },
     "pool": {
       "title": "{{asset}} Pool",
-      "description": "Deposit {{asset}} to farm yield and register LP tokens for actions such as liquidation protection (Aave & Compound)"
+      "description": "Deposit {{asset}} to farm yield and register LP tokens for actions such as liquidation protection (Aave v2 & Compound)"
     },
     "pools": {
       "title": "Backd Pools",
-      "description": "Earn yield and governance tokens while executing other acitons such as collateral top ups (Aave & Compound)"
+      "description": "Earn yield and governance tokens while executing other acitons such as collateral top ups (Aave v2 & Compound)"
     },
     "stake": {
       "title": "Stake BKD & Earn Rewards",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -168,7 +168,7 @@
             "number": "03"
           },
           "register": {
-            "description": "Registra prestamos on-chain de Compound o Aave para recibir top-ups de colateral y depositar tus tokens de LP para obtener recompensas de Backd",
+            "description": "Registra prestamos on-chain de Compound o Aave v2 para recibir top-ups de colateral y depositar tus tokens de LP para obtener recompensas de Backd",
             "header": "Registra prestamos on-chain",
             "number": "02"
           }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -168,7 +168,7 @@
             "number": "03"
           },
           "register": {
-            "description": "Enregistrez vos prêts Compound ou Aave on-chain pour recevoir des remises à niveau de garantie sur vos prêts, et stakez vos tokens LP pour gagnez des primes Backd.",
+            "description": "Enregistrez vos prêts Compound ou Aave v2 on-chain pour recevoir des remises à niveau de garantie sur vos prêts, et stakez vos tokens LP pour gagnez des primes Backd.",
             "header": "Enregistrer votre prêt on-chain",
             "number": "02"
           }

--- a/public/locales/pt_PT/translation.json
+++ b/public/locales/pt_PT/translation.json
@@ -168,7 +168,7 @@
             "number": "03"
           },
           "register": {
-            "description": "Registe empréstimos Compound ou Aave na cadeia para receber top-ups colaterais e stake os seus pool LP tokens para ganhar recompensas em Backd.",
+            "description": "Registe empréstimos Compound ou Aave v2 na cadeia para receber top-ups colaterais e stake os seus pool LP tokens para ganhar recompensas em Backd.",
             "header": "Registar empréstimo na cadeia",
             "number": "02"
           }
@@ -299,7 +299,7 @@
           "invalid": "Endereço inválido",
           "label": "Endereço",
           "required": "O endereço é necessário",
-          "tooltip": "O endereço do proprietário da posição para top-up (por exemplo, se a Alice é o mutuário no Aave que deve ser preenchido, então este seria o endereço da Alice)",
+          "tooltip": "O endereço do proprietário da posição para top-up (por exemplo, se a Alice é o mutuário no Aave v2 que deve ser preenchido, então este seria o endereço da Alice)",
           "unique": "Máximo de uma posição por protocolo e endereço"
         },
         "max": {
@@ -314,7 +314,7 @@
         "protocol": {
           "hover": "Selecionar protocolo",
           "label": "Protocolo",
-          "tooltip": "O protocolo de empréstimo no qual o usuário está a emprestantar fundos (atualmente compatível com Aave e Compound)"
+          "tooltip": "O protocolo de empréstimo no qual o usuário está a emprestantar fundos (atualmente compatível com Aave v2 e Compound)"
         },
         "single": {
           "hover": "Inserir Top-up único",


### PR DESCRIPTION
Currently it is not clear that we only support Aave v2. This PR updates copy throughout the site to refer to Aave v2 specifically when talking about supported lending protocols. Hopefully this combined with us showing the active loan positions of the user should be sufficient in making it clear to the user that we do not support Aave v1.