### PR TITLE
🚀  Add Ordering for Pools

### DIFF
--- a/src/pages/landing/Preview.tsx
+++ b/src/pages/landing/Preview.tsx
@@ -120,7 +120,11 @@ const Preview = (): Optional<JSX.Element> => {
             <Loader row preview />
           </>
         )}
-        {pools && pools.map((pool: Pool) => <PoolsRow key={pool.name} preview pool={pool} />)}
+        {pools &&
+          pools
+            .sort((a: Pool, b: Pool) => (a.apy && b.apy ? b.apy.toNumber() - a.apy.toNumber() : 0))
+            .slice(0, 5)
+            .map((pool: Pool) => <PoolsRow key={pool.name} preview pool={pool} />)}
       </Container>
     </StyledPreview>
   );

--- a/src/pages/pools/PoolsPage.tsx
+++ b/src/pages/pools/PoolsPage.tsx
@@ -16,6 +16,7 @@ import { useWeb3Updated } from "../../app/hooks/use-web3-updated";
 import LiveHelp from "../../components/LiveHelp";
 import Loader from "../../components/Loader";
 import { DOCS_LINK } from "../../lib/links";
+import { selectUsersValuesUsdEverywhere } from "../../state/valueSelectors";
 
 const StyledPoolsPage = styled.div`
   width: 100%;
@@ -92,6 +93,7 @@ const PoolsPage = (): JSX.Element => {
   const dispatch = useDispatch();
   const pools = useSelector(selectPools);
   const updated = useWeb3Updated();
+  const balances = useSelector(selectUsersValuesUsdEverywhere);
 
   useEffect(() => {
     if (!backd) return;
@@ -118,7 +120,16 @@ const PoolsPage = (): JSX.Element => {
                 <Loader row />
               </>
             )}
-            {pools && pools.map((pool: Pool) => <PoolsRow key={pool.address} pool={pool} />)}
+            {pools &&
+              pools
+                .sort((a: Pool, b: Pool) =>
+                  a.apy && b.apy ? b.apy.toNumber() - a.apy.toNumber() : 0
+                )
+                .sort((a: Pool, b: Pool) => {
+                  if (!balances || !balances[a.address] || !balances[b.address]) return 0;
+                  return balances[b.address].toNumber() - balances[a.address].toNumber();
+                })
+                .map((pool: Pool) => <PoolsRow key={pool.address} pool={pool} />)}
           </ContentSection>
         </ContentContainer>
         <InfoCards>


### PR DESCRIPTION
## Pool Ordering
Pools are now ordered by highest deposited first, and then by highest APY

## Reduce Pool Amount on Landing Page
A limit of 5 pools are shown on the landing page.