### PR TITLE
🚀  Hide Paused Pools from Landing Page

### DIFF
--- a/src/lib/binance.test.ts
+++ b/src/lib/binance.test.ts
@@ -4,6 +4,6 @@ test("fetches prices from Binance", async () => {
   const prices = await getPrices(["DAI", "USDC", "ETH"]);
   expect(prices.DAI).toBeCloseTo(1, 0.01);
   expect(prices.USDC).toBeCloseTo(1, 0.01);
-  expect(prices.ETH).toBeGreaterThan(2_000);
+  expect(prices.ETH).toBeGreaterThan(1_000);
   expect(prices.ETH).toBeLessThan(10_000);
 });

--- a/src/lib/coingecko.test.ts
+++ b/src/lib/coingecko.test.ts
@@ -4,6 +4,6 @@ test("fetches prices from Coingecko", async () => {
   const prices = await getPrices(["DAI", "USDC", "ETH"]);
   expect(prices.DAI).toBeCloseTo(1, 0.01);
   expect(prices.USDC).toBeCloseTo(1, 0.01);
-  expect(prices.ETH).toBeGreaterThan(2_000);
+  expect(prices.ETH).toBeGreaterThan(1_000);
   expect(prices.ETH).toBeLessThan(10_000);
 });

--- a/src/pages/landing/Preview.tsx
+++ b/src/pages/landing/Preview.tsx
@@ -122,6 +122,7 @@ const Preview = (): Optional<JSX.Element> => {
         )}
         {pools &&
           pools
+            .filter((pool: Pool) => !pool.isPaused)
             .sort((a: Pool, b: Pool) => (a.apy && b.apy ? b.apy.toNumber() - a.apy.toNumber() : 0))
             .slice(0, 5)
             .map((pool: Pool) => <PoolsRow key={pool.name} preview pool={pool} />)}


### PR DESCRIPTION
We hide them from the pools page already, but we were missing this filter for the landing page.